### PR TITLE
support BYTE_ARRAY type

### DIFF
--- a/pebble/httpebble.py
+++ b/pebble/httpebble.py
@@ -9,6 +9,7 @@ log.setLevel(logging.DEBUG)
 import bridge, uuid, json, urllib2, collections, time
 
 from struct import pack, unpack
+from base64 import b64decode
 
 from pebble import AppMessage
 
@@ -97,9 +98,12 @@ class HTTPebble(bridge.PebbleBridge):
 				t = v[0]
 				v = v[1]
 
-				assert t in self.type_conversion
-				t = self.type_conversion[t]
-				vals.append((k, t[0], pack('<%s' % t[1], v)))
+				if t == 'd':
+					vals.append((k, "BYTE_ARRAY", b64decode(v)))
+				else:
+					assert t in self.type_conversion
+					t = self.type_conversion[t]
+					vals.append((k, t[0], pack('<%s' % t[1], v)))
 			elif type(v) is int:
 				vals.append((k, "INT", pack('<i', v)))
 			else:


### PR DESCRIPTION
This adds support for forwarding [binary data tuples](https://github.com/Katharine/httpebble-watch/issues/3) from the server.
